### PR TITLE
v1.2.0 - use IAP to connect to VMs

### DIFF
--- a/.github/workflows/packer.yaml
+++ b/.github/workflows/packer.yaml
@@ -42,7 +42,7 @@ jobs:
         with:
           version: 'latest'
           project_id: '${{ vars.GCP_PROJECT_ID }}'
-          install_components: 'beta'  # optional: install additional components
+          #install_components: 'beta'  # optional: install additional components
 
       - name: Setup `packer`
         uses: hashicorp/setup-packer@main
@@ -81,6 +81,12 @@ jobs:
         with:
           workload_identity_provider: '${{ secrets.WIF_PROVIDER }}'
           service_account: '${{ secrets.WIF_SERVICE_ACCOUNT }}'
+      - name: 'Set up Google Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+        with:
+          version: 'latest'
+          project_id: '${{ vars.GCP_PROJECT_ID }}'
+          #install_components: 'beta'  # optional: install additional components
 
       - name: Setup `packer`
         uses: hashicorp/setup-packer@main
@@ -119,6 +125,12 @@ jobs:
         with:
           workload_identity_provider: '${{ secrets.WIF_PROVIDER }}'
           service_account: '${{ secrets.WIF_SERVICE_ACCOUNT }}'
+      - name: 'Set up Google Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+        with:
+          version: 'latest'
+          project_id: '${{ vars.GCP_PROJECT_ID }}'
+          #install_components: 'beta'  # optional: install additional components
 
       - name: Setup `packer`
         uses: hashicorp/setup-packer@main
@@ -158,6 +170,12 @@ jobs:
         with:
           workload_identity_provider: '${{ secrets.WIF_PROVIDER }}'
           service_account: '${{ secrets.WIF_SERVICE_ACCOUNT }}'
+      - name: 'Set up Google Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+        with:
+          version: 'latest'
+          project_id: '${{ vars.GCP_PROJECT_ID }}'
+          #install_components: 'beta'  # optional: install additional components
 
       - name: Setup `packer`
         uses: hashicorp/setup-packer@main
@@ -197,6 +215,12 @@ jobs:
         with:
           workload_identity_provider: '${{ secrets.WIF_PROVIDER }}'
           service_account: '${{ secrets.WIF_SERVICE_ACCOUNT }}'
+      - name: 'Set up Google Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+        with:
+          version: 'latest'
+          project_id: '${{ vars.GCP_PROJECT_ID }}'
+          #install_components: 'beta'  # optional: install additional components
 
       - name: Setup `packer`
         uses: hashicorp/setup-packer@main
@@ -236,6 +260,12 @@ jobs:
         with:
           workload_identity_provider: '${{ secrets.WIF_PROVIDER }}'
           service_account: '${{ secrets.WIF_SERVICE_ACCOUNT }}'
+      - name: 'Set up Google Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+        with:
+          version: 'latest'
+          project_id: '${{ vars.GCP_PROJECT_ID }}'
+          #install_components: 'beta'  # optional: install additional components
 
       - name: Setup `packer`
         uses: hashicorp/setup-packer@main

--- a/.github/workflows/packer.yaml
+++ b/.github/workflows/packer.yaml
@@ -2,7 +2,7 @@ name: Packer Build
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
     paths-ignore: ['**/README.md','**/CHANGELOG.md', 'terraform/*']
 
 env:
@@ -37,6 +37,12 @@ jobs:
         with:
           workload_identity_provider: '${{ secrets.WIF_PROVIDER }}'
           service_account: '${{ secrets.WIF_SERVICE_ACCOUNT }}'
+      - name: 'Set up Google Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+        with:
+          version: 'latest'
+          project_id: '${{ vars.GCP_PROJECT_ID }}'
+          install_components: 'beta'  # optional: install additional components
 
       - name: Setup `packer`
         uses: hashicorp/setup-packer@main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.2.0] - 2025-??-??
 ### Added
 - `dev` branch to GHA trigger
-- `Set up Google Cloud SDK` step to the GHA job steps
-- using IAP to connect to the VM to build (which requires Google Cloud SDK)
-- `use_iap` = true
-- `preemptible` = true
+- Set up Google Cloud SDK (`google-github-actions/setup-gcloud@v2`) step to the GHA job steps
+- Using IAP to connect to the VM to build, which requires Google Cloud SDK (`use_iap = true`)
+- Packer variable `machine_type` (default: `n2-standard-4`)
+- Using preemptible VM instance (`preemptible = true`)
 ### Changed
 - Updated Consul version from `1.20.5` to `1.21.0`
 - Updated Nomad version from `1.9.7` to `1.10.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [1.2.0] - 2025-??-??
+### Added
+- `dev` branch to GHA trigger
+- `Set up Google Cloud SDK` step to the GHA job steps
+- using IAP to connect to the VM to build (which requires Google Cloud SDK)
+- `use_iap` = true
+- `preemptible` = true
+### Changed
+- Updated Consul version from `1.20.5` to `1.21.0`
+- Updated Nomad version from `1.9.7` to `1.10.0`
+- Updated Vault version from `1.19.0` to `1.19.3`
+
 ## [1.1.0] - 2025-03-26
 ### Added
 - Consul backend storage config example to `vault_server.hcl.sample`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-## [1.2.0] - 2025-??-??
+## [1.2.0] - 2025-05-11
 ### Added
 - `dev` branch to GHA trigger
 - Set up Google Cloud SDK (`google-github-actions/setup-gcloud@v2`) step to the GHA job steps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Using IAP to connect to the VM to build, which requires Google Cloud SDK (`use_iap = true`)
 - Packer variable `machine_type` (default: `n2-standard-4`)
 - Using preemptible VM instance (`preemptible = true`)
+- GCP firewall rule for to allow IAP tunneling
 ### Changed
 - Updated Consul version from `1.20.5` to `1.21.0`
 - Updated Nomad version from `1.9.7` to `1.10.0`

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ You will need to add the following secrets to GitHub:
 - `HCP_CLIENT_SECRET`
 
 **NOTE**: You can track up to ~~[10 buckets (images) for free](https://www.hashicorp.com/products/packer/pricing)~~, but if you do not wish to, you can always comment out `hcp_packer_registry` block from the image build template file(s).
+
 **UPDATE**: As of [v1.1.0](https://github.com/Neutrollized/packer-gcp-with-githubactions/blob/main/CHANGELOG.md#110---2025-03-26), due to recent HCP Packer pricing changes, there's no longer a free tier and hence I've commented out `hcp_packer_registry` references as it's always been my goal to keep my repos/deployments as cost-effective as possible for learning.
 
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 [Medium: Getting started with HashiCorp Packer on Google Cloud Platform](https://medium.com/@glen.yu/getting-started-with-hashicorp-packer-on-google-cloud-platform-a36bfeffbfa9)
 
+I'm also using larger machine types (i.e. *n2-standard-4*), but with [preemptible VM instances](https://cloud.google.com/compute/docs/instances/preemptible) which should both speed up the build process and reduce overall cost.
+
 ## Setup
 
 ### 0 - Fork this repo
@@ -45,7 +47,7 @@ jobs:
 
       - name: 'Authenticate to Google Cloud'
         id: 'auth'
-        uses: 'google-github-actions/auth@v1'
+        uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: '${{ secrets.GCP_CREDENTIALS_JSON }}'
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Terraform code for setting up required GCP service accounts and WIF can be found
 You will need to update the `WIF_PROVIDER` and `WIF_SERVICE_ACCOUNT` env vars in the [packer.yaml](.github/workflow/packer.yaml) accordingly for your GCP project and WIF Pool configuration
 
 #### NOTE - You can get the `WIF_PROVIDER` with the following `gcloud` command (provider ID = *github* in my example): 
-```console
+```sh
 gcloud iam workload-identity-pools providers describe ${WIF_PROVIDER_ID} \
     --location global \
     --workload-identity-pool ${WIF_POOL_ID} \
@@ -38,7 +38,7 @@ Check the **Actions** tab and watch it go
 
 #### NOTE - Using Credentials JSON
 While not the recommended method of authenticating to Google Cloud, you can generate a credentials JSON key file and paste its contents into a GitHub repo secret:
-```
+```console
 jobs:
     [...]
 
@@ -74,11 +74,11 @@ You will need to add the following secrets to GitHub:
 If you wish to run this locally without using GitHub Actions, you can do the following:
 
 - authenticate using user application default creds
-```console
+```sh
 gcloud auth application-default login
 ```
 
-```console
+```sh
 packer init base_docker.pkr.hcl
 
 PKR_VAR_access_token='xxxxxxxxxxxxx' packer build -var 'project_id=myproject-123' -var-file=variables.pkrvars.hcl base_docker.pkr.hcl`

--- a/base-docker/base_docker.pkr.hcl
+++ b/base-docker/base_docker.pkr.hcl
@@ -32,10 +32,9 @@ source "googlecompute" "base-docker" {
   # gcloud compute images list
   source_image_family = var.source_image_family
 
-  image_family       = var.image_family
-  image_architecture = upper(var.arch)  # expected to be uppercase 
-  image_name         = "docker-${var.arch}-base-${local.datestamp}"
-  image_description  = "Debian 12 image with Docker-CE installed"
+  image_family      = var.image_family
+  image_name        = "docker-${var.arch}-base-${local.datestamp}"
+  image_description = "Debian 12 image with Docker-CE installed"
   
   ssh_username = "packer"
   use_os_login = false

--- a/base-docker/base_docker.pkr.hcl
+++ b/base-docker/base_docker.pkr.hcl
@@ -31,10 +31,9 @@ source "googlecompute" "base-docker" {
   # gcloud compute images list
   source_image_family = var.source_image_family
 
-  image_family       = var.image_family
-  image_architecture = var.arch
-  image_name         = "docker-${var.arch}-base-${local.datestamp}"
-  image_description  = "Debian 12 image with Docker-CE installed"
+  image_family      = var.image_family
+  image_name        = "docker-${var.arch}-base-${local.datestamp}"
+  image_description = "Debian 12 image with Docker-CE installed"
   
   ssh_username = "packer"
   use_os_login = false

--- a/base-docker/base_docker.pkr.hcl
+++ b/base-docker/base_docker.pkr.hcl
@@ -26,15 +26,19 @@ source "googlecompute" "base-docker" {
   project_id   = var.project_id
   zone         = var.zone
   machine_type = "n1-standard-2"
-  ssh_username = "packer"
-  use_os_login = "false"
+  preemptible  = true
 
   # gcloud compute images list
   source_image_family = var.source_image_family
 
-  image_family      = var.image_family
-  image_name        = "docker-${var.arch}-base-${local.datestamp}"
-  image_description = "Debian 12 image with Docker-CE installed"
+  image_family       = var.image_family
+  image_architecture = var.arch
+  image_name         = "docker-${var.arch}-base-${local.datestamp}"
+  image_description  = "Debian 12 image with Docker-CE installed"
+  
+  ssh_username = "packer"
+  use_os_login = false
+  use_iap      = true
 
   tags = ["packer"]
 }

--- a/base-docker/base_docker.pkr.hcl
+++ b/base-docker/base_docker.pkr.hcl
@@ -12,6 +12,7 @@ packer {
 variable "project_id" {}
 variable "zone" {}
 variable "arch" {}
+variable "machine_type" {}
 variable "source_image_family" {}
 variable "image_family" {}
 
@@ -25,15 +26,16 @@ locals {
 source "googlecompute" "base-docker" {
   project_id   = var.project_id
   zone         = var.zone
-  machine_type = "n1-standard-2"
+  machine_type = var.machine_type
   preemptible  = true
 
   # gcloud compute images list
   source_image_family = var.source_image_family
 
-  image_family      = var.image_family
-  image_name        = "docker-${var.arch}-base-${local.datestamp}"
-  image_description = "Debian 12 image with Docker-CE installed"
+  image_family       = var.image_family
+  image_architecture = upper(var.arch)  # expected to be uppercase 
+  image_name         = "docker-${var.arch}-base-${local.datestamp}"
+  image_description  = "Debian 12 image with Docker-CE installed"
   
   ssh_username = "packer"
   use_os_login = false

--- a/base-docker/variables.pkrvars.hcl
+++ b/base-docker/variables.pkrvars.hcl
@@ -1,4 +1,5 @@
 zone                = "northamerica-northeast2-c"
 arch                = "amd64"
+machine_type        = "n2-standard-4"
 source_image_family = "debian-12"
 image_family        = "custom-docker-base"

--- a/hashistack/consul_base.pkr.hcl
+++ b/hashistack/consul_base.pkr.hcl
@@ -12,6 +12,7 @@ packer {
 variable "project_id" {}
 variable "zone" {}
 variable "arch" {}
+variable "machine_type" {}
 variable "source_image_family" {}
 variable "image_family" {}
 variable "consul_version" {}
@@ -30,9 +31,8 @@ locals {
 source "googlecompute" "consul-base" {
   project_id   = var.project_id
   zone         = var.zone
-  machine_type = "n1-standard-2"
-  ssh_username = "packer"
-  use_os_login = "false"
+  machine_type = var.machine_type
+  preemptible  = true
 
   # use custom base image that was built
   source_image_family = var.source_image_family
@@ -40,6 +40,10 @@ source "googlecompute" "consul-base" {
   image_family      = var.image_family
   image_name        = "consul-${local.image_consul_version}-${var.arch}-base-${local.datestamp}"
   image_description = "Consul base image"
+
+  ssh_username = "packer"
+  use_os_login = false
+  use_iap      = true
 
   tags = ["packer"]
 }

--- a/hashistack/consul_server.pkr.hcl
+++ b/hashistack/consul_server.pkr.hcl
@@ -12,6 +12,7 @@ packer {
 variable "project_id" {}
 variable "zone" {}
 variable "arch" {}
+variable "machine_type" {}
 variable "source_image_family" {}
 variable "image_family" {}
 variable "consul_version" {}
@@ -30,9 +31,8 @@ locals {
 source "googlecompute" "consul-server" {
   project_id   = var.project_id
   zone         = var.zone
-  machine_type = "n1-standard-2"
-  ssh_username = "packer"
-  use_os_login = "false"
+  machine_type = var.machine_type
+  preemptible  = true
 
   # use custom base image that was built
   source_image_family = var.source_image_family
@@ -40,6 +40,10 @@ source "googlecompute" "consul-server" {
   image_family      = var.image_family
   image_name        = "consul-${local.image_consul_version}-${var.arch}-server-${local.datestamp}"
   image_description = "Consul server image"
+
+  ssh_username = "packer"
+  use_os_login = false
+  use_iap      = true
 
   tags = ["packer"]
 }

--- a/hashistack/nomad_client.pkr.hcl
+++ b/hashistack/nomad_client.pkr.hcl
@@ -12,6 +12,7 @@ packer {
 variable "project_id" {}
 variable "zone" {}
 variable "arch" {}
+variable "machine_type" {}
 variable "source_image_family" {}
 variable "image_family" {}
 variable "consul_version" {}
@@ -32,9 +33,8 @@ locals {
 source "googlecompute" "nomad-client" {
   project_id   = var.project_id
   zone         = var.zone
-  machine_type = "n1-standard-2"
-  ssh_username = "packer"
-  use_os_login = "false"
+  machine_type = var.machine_type
+  preemptible  = true
 
   # use custom base image that was built
   source_image_family = var.source_image_family
@@ -42,6 +42,10 @@ source "googlecompute" "nomad-client" {
   image_family      = var.image_family
   image_name        = "nomad-${local.image_nomad_version}-${var.arch}-client-${local.datestamp}"
   image_description = "Nomad client image"
+
+  ssh_username = "packer"
+  use_os_login = false
+  use_iap      = true
 
   tags = ["packer"]
 }

--- a/hashistack/nomad_server.pkr.hcl
+++ b/hashistack/nomad_server.pkr.hcl
@@ -12,6 +12,7 @@ packer {
 variable "project_id" {}
 variable "zone" {}
 variable "arch" {}
+variable "machine_type" {}
 variable "source_image_family" {}
 variable "image_family" {}
 variable "nomad_version" {}
@@ -30,9 +31,8 @@ locals {
 source "googlecompute" "nomad-server" {
   project_id   = var.project_id
   zone         = var.zone
-  machine_type = "n1-standard-2"
-  ssh_username = "packer"
-  use_os_login = "false"
+  machine_type = var.machine_type
+  preemptible  = true
 
   # use custom base image that was built
   source_image_family = var.source_image_family
@@ -40,6 +40,10 @@ source "googlecompute" "nomad-server" {
   image_family      = var.image_family
   image_name        = "nomad-${local.image_nomad_version}-${var.arch}-server-${local.datestamp}"
   image_description = "Nomad server image"
+
+  ssh_username = "packer"
+  use_os_login = false
+  use_iap      = true
 
   tags = ["packer"]
 }

--- a/hashistack/variables.pkrvars.hcl
+++ b/hashistack/variables.pkrvars.hcl
@@ -1,6 +1,6 @@
 zone = "northamerica-northeast2-c"
 arch = "amd64"
 
-consul_version = "1.20.5"
-nomad_version  = "1.9.7"
-vault_version  = "1.19.0"
+consul_version = "1.21.0"
+nomad_version  = "1.10.0"
+vault_version  = "1.19.3"

--- a/hashistack/variables.pkrvars.hcl
+++ b/hashistack/variables.pkrvars.hcl
@@ -1,5 +1,6 @@
-zone = "northamerica-northeast2-c"
-arch = "amd64"
+zone         = "northamerica-northeast2-c"
+arch         = "amd64"
+machine_type = "n2-standard-4"
 
 consul_version = "1.21.0"
 nomad_version  = "1.10.0"

--- a/hashistack/vault_base.pkr.hcl
+++ b/hashistack/vault_base.pkr.hcl
@@ -12,6 +12,7 @@ packer {
 variable "project_id" {}
 variable "zone" {}
 variable "arch" {}
+variable "machine_type" {}
 variable "source_image_family" {}
 variable "image_family" {}
 variable "vault_version" {}
@@ -30,9 +31,8 @@ locals {
 source "googlecompute" "vault-base" {
   project_id   = var.project_id
   zone         = var.zone
-  machine_type = "n1-standard-2"
-  ssh_username = "packer"
-  use_os_login = "false"
+  machine_type = var.machine_type
+  preemptible  = true
 
   # use custom base image that was built
   source_image_family = var.source_image_family
@@ -40,6 +40,10 @@ source "googlecompute" "vault-base" {
   image_family      = var.image_family
   image_name        = "vault-${local.image_vault_version}-${var.arch}-base-${local.datestamp}"
   image_description = "Vault base image"
+
+  ssh_username = "packer"
+  use_os_login = false
+  use_iap      = true
 
   tags = ["packer"]
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -27,6 +27,7 @@ variable "packer_sa_iam_roles_list" {
   default = [
     "roles/compute.instanceAdmin.v1",
     "roles/iam.serviceAccountUser",
+    "roles/iap.tunnelResourceAccessor",
   ]
 }
 


### PR DESCRIPTION
- added Cloud SDK setup in GHA steps
- builds use IAP to connect to VM (which requires GHA runner to have Cloud SDK setup)
- add GCP firewall rule to allow IAP tunneling
- using preemptible VMs + larger machine types